### PR TITLE
Add dependency for automake

### DIFF
--- a/Library/Formula/autoconf.rb
+++ b/Library/Formula/autoconf.rb
@@ -13,6 +13,8 @@ class Autoconf < Formula
   end
 
   keg_only :provided_until_xcode43
+  
+  depends_on "automake"
 
   def install
     ENV["PERL"] = "/usr/bin/perl"


### PR DESCRIPTION
Autoconf requires automake. Without automake installed you don't have aclocal which means you get errors like:
`Can't exec "aclocal": No such file or directory at /usr/local/Cellar/autoconf/2.69/share/autoconf/Autom4te/FileUtils.pm line 326.
autoreconf: failed to run aclocal: No such file or directory`
